### PR TITLE
Upgrade to Kotlin 1.0.0-beta-2422 & TeaVM 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About
 =====
 
-This is Gradle plugin for compiling(transpiling) Java bytecode to JavaScript using [TeaVM](http://teavm.org/). Plugin uses TeaVMTool for compilation. Plugin is written in [Kotlin](http://kotlinlang.org/) and depends on `kotlin-stdlib`. Project that uses plugin will depend on `teavm-classlib`, `teavm-jso` and `teavm-dom`. All dependencies can be acquired from Maven Central repo.
+This is Gradle plugin for compiling(transpiling) Java bytecode to JavaScript using [TeaVM](http://teavm.org/). Plugin uses TeaVMTool for compilation. Plugin is written in [Kotlin](http://kotlinlang.org/) and depends on `kotlin-stdlib`. Project that uses plugin will depend on `teavm-classlib`, `teavm-jso` and `teavm-jso-apis`. All dependencies can be acquired from Maven Central repo.
 
 Plugin is tested with Java 6 and Kotlin but it should be able to transpile other JVM outputs too.
 

--- a/teavm-gradle-plugin/build.gradle
+++ b/teavm-gradle-plugin/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'kotlin'
 apply plugin: 'maven-publish'
 
 sourceCompatibility = JavaVersion.VERSION_1_6
-version = '0.3.2.0'
+version = '0.4.0.0'
 group = "com.edibleday"
 
 repositories {
@@ -22,7 +22,8 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'org.teavm:teavm-core:0.3.2'
+    compile 'org.teavm:teavm-core:0.4.0'
+    compile 'org.teavm:teavm-tooling:0.4.0'
     compile 'org.jetbrains.kotlin:kotlin-stdlib:1.0.0-beta-2422'
     compile 'org.apache.maven:maven-plugin-api:3.3.3'
 }

--- a/teavm-gradle-plugin/build.gradle
+++ b/teavm-gradle-plugin/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:0.12.613"
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.0.0-beta-2422'
     }
 }
 
@@ -22,8 +22,9 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile "org.teavm:teavm-core:0.3.2"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:0.12.613"
+    compile 'org.teavm:teavm-core:0.3.2'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.0.0-beta-2422'
+    compile 'org.apache.maven:maven-plugin-api:3.3.3'
 }
 
 task sourceJar(type: Jar) {

--- a/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMPlugin.kt
+++ b/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMPlugin.kt
@@ -21,7 +21,7 @@ import org.gradle.api.Task
 
 public class TeaVMPlugin : Plugin<Project> {
 
-    val version = "0.3.2"
+    val version = "0.4.0"
 
     override fun apply(project: Project) {
 
@@ -38,11 +38,11 @@ public class TeaVMPlugin : Plugin<Project> {
         project.getDependencies().let {
             it.add("compile", "org.teavm:teavm-classlib:$version")
             it.add("compile", "org.teavm:teavm-jso:$version")
-            it.add("compile", "org.teavm:teavm-dom:$version")
+            it.add("compile", "org.teavm:teavm-jso-apis:$version")
             it.add("teavmsources", "org.teavm:teavm-platform:$version:sources")
             it.add("teavmsources", "org.teavm:teavm-classlib:$version:sources")
             it.add("teavmsources", "org.teavm:teavm-jso:$version:sources")
-            it.add("teavmsources", "org.teavm:teavm-dom:$version:sources")
+            it.add("teavmsources", "org.teavm:teavm-jso-apis:$version:sources")
         }
 
 

--- a/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMPlugin.kt
+++ b/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMPlugin.kt
@@ -47,7 +47,7 @@ public class TeaVMPlugin : Plugin<Project> {
 
 
         project.task(mapOf(
-                Task.TASK_TYPE to javaClass<TeaVMTask>(),
+                Task.TASK_TYPE to TeaVMTask::class.java,
                 Task.TASK_DEPENDS_ON to "build",
                 Task.TASK_DESCRIPTION to "TeaVM Compile",
                 Task.TASK_GROUP to "build"

--- a/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMTask.kt
+++ b/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMTask.kt
@@ -31,8 +31,6 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.net.URLClassLoader
 import java.util.ArrayList
-import kotlin.properties.Delegates
-
 
 public open class TeaVMTask : DefaultTask() {
 
@@ -44,9 +42,9 @@ public open class TeaVMTask : DefaultTask() {
     public var minified: Boolean = true
     public var runtime: RuntimeCopyOperation = RuntimeCopyOperation.SEPARATE
 
-    val log by Delegates.lazy { TeaVMLoggerGlue(getProject().getLogger()) }
+    val log by lazy { TeaVMLoggerGlue(getProject().getLogger()) }
 
-    TaskAction public fun compTeaVM() {
+    @TaskAction public fun compTeaVM() {
         val tool = TeaVMTool()
         val project = getProject()
 
@@ -73,7 +71,7 @@ public open class TeaVMTask : DefaultTask() {
         }
 
 
-        val convention = project.getConvention().getPlugin(javaClass<JavaPluginConvention>())
+        val convention = project.getConvention().getPlugin(JavaPluginConvention::class.java)
 
         convention
                 .getSourceSets()
@@ -115,14 +113,14 @@ public open class TeaVMTask : DefaultTask() {
             val urls = ArrayList<URL>()
             val classpath = StringBuilder()
             for (file in getProject().getConfigurations().getByName("runtime").getFiles()) {
-                if (classpath.length() > 0) {
+                if (classpath.length > 0) {
                     classpath.append(':')
                 }
                 classpath.append(file.getPath())
                 urls.add(file.toURI().toURL())
             }
 
-            if (classpath.length() > 0) {
+            if (classpath.length > 0) {
                 classpath.append(':')
             }
             classpath.append(File(getProject().getBuildDir(), "classes/main").getPath())
@@ -131,7 +129,7 @@ public open class TeaVMTask : DefaultTask() {
             classpath.append(File(getProject().getBuildDir(), "resources/main").getPath())
             urls.add(File(getProject().getBuildDir(), "resources/main").toURI().toURL())
 
-            return URLClassLoader(urls.toArray<URL>(arrayOfNulls<URL>(urls.size())), javaClass.getClassLoader())
+            return URLClassLoader(urls.toArray<URL>(arrayOfNulls<URL>(urls.size)), javaClass.getClassLoader())
         } catch (e: MalformedURLException) {
             throw MojoExecutionException("Error gathering classpath information", e)
         }

--- a/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMTask.kt
+++ b/teavm-gradle-plugin/src/main/kotlin/com/edibleday/TeaVMTask.kt
@@ -21,8 +21,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
-import org.teavm.tooling.DirectorySourceFileProvider
-import org.teavm.tooling.JarSourceFileProvider
+import org.teavm.tooling.sources.DirectorySourceFileProvider
+import org.teavm.tooling.sources.JarSourceFileProvider
 import org.teavm.tooling.RuntimeCopyOperation
 import org.teavm.tooling.TeaVMTool
 import java.io.File

--- a/teavm-plugin-sample/build.gradle
+++ b/teavm-plugin-sample/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.edibleday:teavm-gradle-plugin:0.3.2.+" //Depend on plugin
+        classpath "com.edibleday:teavm-gradle-plugin:0.4.0.+" //Depend on plugin
     }
 }
 

--- a/teavm-plugin-sample/src/main/java/Main.java
+++ b/teavm-plugin-sample/src/main/java/Main.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import org.teavm.dom.browser.Window;
-import org.teavm.jso.JS;
+import org.teavm.jso.browser.Window;
 
 public class Main
 {
 	public static void main(String[] args)
 	{
-		final Window window = ((Window) JS.getGlobal());
+		final Window window = Window.current();
 		window.alert("Hello from TeaVM!");
 	}
 }


### PR DESCRIPTION
Had some issues compiling `teavm-gradle-plugin` in the compileKotlin stage freshly checked out (as of `acb9c9f`), and as I ventured to fix this I took it upon myself to also upgrade the plugin to a newer version of Kotlin, and to use TeaVM 0.4.0 instead of 0.3.2.

Thought perhaps you'd be interested in it too.

For reference, the original problem I had was this:

``` :teavm-gradle-plugin:compileKotlin
e: teavm-gradle-plugin\src\main\kotlin\com\edibleday\TeaVMTask.kt: (19, 25): Unresolved reference: plugin
e: teavm-gradle-plugin\teavm-gradle-plugin\src\main\kotlin\com\edibleday\TeaVMTask.kt: (136, 19): Unresolved reference: MojoExecutionException
:teavm-gradle-plugin:compileKotlin FAILED
```

Which was probably just missing a reference to the `maven-plugin-api` dependency...
